### PR TITLE
Added NOFETCH option to prevent git reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ If you're a games publisher and you'd like LAN parties, gaming centers and other
 
 If you have any questions, please check [our FAQs](faq.md). If this doesn't answer your question, please raise an issue in GitHub.
 
+## How to help out
+To build just run `docker build --tag lancachenet/monolithic:testing .`. To test you can run `./run_tests.sh`
+
+If you want to test a new build with a forked uklans repo/branch you can specify `-e CACHE_DOMAIN_REPO=""` and even `-e NOFETCH=true` if using a locally bind mounted git repo.
+
 ## Thanks
 
  - Based on original configs from [ansible-lanparty](https://github.com/ti-mo/ansible-lanparty).

--- a/overlay/hooks/entrypoint-pre.d/15_generate_maps.sh
+++ b/overlay/hooks/entrypoint-pre.d/15_generate_maps.sh
@@ -7,8 +7,11 @@ export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostCACHE_I
 if [[ ! -d .git ]]; then
 	git clone ${CACHE_DOMAIN_REPO} .
 fi
-git fetch origin
-git reset --hard origin/master
+
+if [[ "${NOFETCH:-false}" != "true" ]]; then
+	git fetch origin
+	git reset --hard origin/master
+fi
 TEMP_PATH=$(mktemp -d)
 OUTPUTFILE=${TEMP_PATH}/outfile.conf
 echo "map \$http_host \$cacheidentifier {" >> $OUTPUTFILE


### PR DESCRIPTION
When developing/updating the uklans repo it is helpful to bind mount a
local copy for testing.

-e NOFETCH=true

Resolves #41