### PR TITLE
Removed "t" for terabytes in cache sizing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ In addition, there is an environment variable to control the max cache age.
 CACHE_MAX_AGE 3560d
 ````
 
-You can override these at run time by adding the following to your docker run command.  They accept the standard nginx notation for sizes (k/m/g/t) and durations (m/h/d).
+You can override these at run time by adding the following to your docker run command.  They accept the standard nginx notation for sizes (k/m/g) and durations (m/h/d).
 
 ```
 -e CACHE_MEM_SIZE=4000m -e CACHE_DISK_SIZE=1000g -e CACHE_MAX_AGE 3560d


### PR DESCRIPTION
Former instruction "They accept the standard nginx notation for sizes (k/m/g/t)" tests incorrect. "t" is not supported.