### PR TITLE
WIP: Added healthcheck litmus test site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,15 @@ ENV CACHE_DOMAINS_REPO https://github.com/uklans/cache-domains.git
 ENV CACHE_DOMAINS_BRANCH master
 ENV UPSTREAM_DNS 8.8.8.8 8.8.4.4
 ENV NGINX_WORKER_PROCESSES auto
-
-COPY overlay/ /
+ENV HEALTHCHECK_HOSTNAME lancache.lan
+ENV HEALTHCHECK_ENABLE true
 
 RUN mkdir -m 755 -p /data/cachedomains		;\
 	mkdir -m 755 -p /tmp/nginx				;\
 	apt-get update							;\
 	apt-get install -y jq git				;
 
+COPY overlay/ /
 
 VOLUME ["/data/logs", "/data/cache", "/data/cachedomains", "/var/www"]
 

--- a/overlay/etc/nginx/sites-available/20_healthcheck.conf
+++ b/overlay/etc/nginx/sites-available/20_healthcheck.conf
@@ -1,0 +1,9 @@
+server {
+  listen 80;
+
+  access_log /data/logs/access.log cachelog;
+  error_log /data/logs/error.log;
+
+
+  include /etc/nginx/sites-available/healthcheck.conf.d/*.conf;
+}

--- a/overlay/etc/nginx/sites-available/generic.conf.d/10_generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/10_generic.conf
@@ -1,0 +1,19 @@
+  resolver 8.8.8.8 8.8.4.4 ipv6=off;
+
+  location / {
+
+          include /etc/nginx/sites-available/generic.conf.d/root/*.conf;
+
+  }
+
+  # Fix for League of Legends Updater
+  location ~ ^.+(releaselisting_.*|.version$) {
+    proxy_pass http://$host;
+  }
+
+  location = /steamcache-heartbeat {
+        add_header X-LanCache-Processed-By $hostname;
+        add_header 'Access-Control-Expose-Headers' '*';
+        add_header 'Access-Control-Allow-Origin' '*';
+        return 204;
+  }

--- a/overlay/etc/nginx/sites-available/healthcheck.conf.d/10_healthcheck.conf
+++ b/overlay/etc/nginx/sites-available/healthcheck.conf.d/10_healthcheck.conf
@@ -1,0 +1,3 @@
+server_name lancache HEALTHCHECK_HOSTNAME;
+
+root /var/www/healthcheck;

--- a/overlay/hooks/entrypoint-pre.d/99_generate_statuspage.sh
+++ b/overlay/hooks/entrypoint-pre.d/99_generate_statuspage.sh
@@ -20,9 +20,12 @@ echo "var cachedomains = {" >> $OUTPUTFILE
 jq -r '.cache_domains | to_entries[] | .key' cache_domains.json | while read CACHE_ENTRY; do 
 	# for each cache entry, find the cache indentifier
 	CACHE_IDENTIFIER=$(jq -r ".cache_domains[$CACHE_ENTRY].name" cache_domains.json)
+	CACHE_DESCRIPTION=$(jq -r ".cache_domains[$CACHE_ENTRY].description" cache_domains.json)
 	jq -r ".cache_domains[$CACHE_ENTRY].domain_files | to_entries[] | .key" cache_domains.json | while read CACHEHOSTS_FILEID; do
 		# Get the key for each domain files
-		echo "	\"${CACHE_IDENTIFIER}\": [" >> $OUTPUTFILE
+		echo "	\"${CACHE_IDENTIFIER}\": {" >> $OUTPUTFILE
+		echo "		\"description\": \"${CACHE_DESCRIPTION}\"," >> $OUTPUTFILE
+		echo "		\"domains\": [" >> $OUTPUTFILE
 		jq -r ".cache_domains[$CACHE_ENTRY].domain_files[$CACHEHOSTS_FILEID]" cache_domains.json | while read CACHEHOSTS_FILENAME; do
 			# Get the actual file name
 			cat ${CACHEHOSTS_FILENAME} | while read CACHE_HOST; do
@@ -33,11 +36,12 @@ jq -r '.cache_domains | to_entries[] | .key' cache_domains.json | while read CAC
 					continue;
 				fi
 				if [ ! "x${CACHE_HOST}" == "x" ]; then
-					echo "		\"${CACHE_HOST}\"," >> $OUTPUTFILE
+					echo "			\"${CACHE_HOST}\"," >> $OUTPUTFILE
 				fi
 			done
 		done
-		echo "	]," >> $OUTPUTFILE
+		echo "		]" >> $OUTPUTFILE
+		echo "	}," >> $OUTPUTFILE
 	done
 done
 echo "};" >> $OUTPUTFILE

--- a/overlay/hooks/entrypoint-pre.d/99_generate_statuspage.sh
+++ b/overlay/hooks/entrypoint-pre.d/99_generate_statuspage.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+if [[ HEALTHCHECK_ENABLE == false ]]; then
+	exit 0
+fi
+
+
+IFS=' '
+mkdir -p /data/cachedomains
+cd /data/cachedomains
+
+if [ ! -f /etc/nginx/sites-enabled/20_healthcheck.conf ]; then
+	ln -s /etc/nginx/sites-available/20_healthcheck.conf /etc/nginx/sites-enabled/20_healthcheck.conf
+fi
+sed -i "s/HEALTHCHECK_HOSTNAME/${HEALTHCHECK_HOSTNAME}/" /etc/nginx/sites-available/healthcheck.conf.d/10_healthcheck.conf
+
+TEMP_PATH=$(mktemp -d)
+OUTPUTFILE=${TEMP_PATH}/outfile.conf
+echo "var cachedomains = {" >> $OUTPUTFILE
+jq -r '.cache_domains | to_entries[] | .key' cache_domains.json | while read CACHE_ENTRY; do 
+	# for each cache entry, find the cache indentifier
+	CACHE_IDENTIFIER=$(jq -r ".cache_domains[$CACHE_ENTRY].name" cache_domains.json)
+	jq -r ".cache_domains[$CACHE_ENTRY].domain_files | to_entries[] | .key" cache_domains.json | while read CACHEHOSTS_FILEID; do
+		# Get the key for each domain files
+		echo "	\"${CACHE_IDENTIFIER}\": [" >> $OUTPUTFILE
+		jq -r ".cache_domains[$CACHE_ENTRY].domain_files[$CACHEHOSTS_FILEID]" cache_domains.json | while read CACHEHOSTS_FILENAME; do
+			# Get the actual file name
+			cat ${CACHEHOSTS_FILENAME} | while read CACHE_HOST; do
+				# for each file in the hosts file
+				# remove all whitespace (mangles comments but ensures valid config files)
+				CACHE_HOST=${CACHE_HOST// /}
+				if [[ ${CACHE_HOST:0:1} == '#' ]]; then
+					continue;
+				fi
+				if [ ! "x${CACHE_HOST}" == "x" ]; then
+					echo "		\"${CACHE_HOST}\"," >> $OUTPUTFILE
+				fi
+			done
+		done
+		echo "	]," >> $OUTPUTFILE
+	done
+done
+echo "};" >> $OUTPUTFILE
+if [[ -d .git ]]; then
+	giturl=$(git config --get remote.origin.url)
+	echo "var urltext='Running with hostlist from <a target=\"_blank\" href=\"${giturl}\">${giturl}</a>';" >> $OUTPUTFILE;
+else
+	echo "var urltext='Running with an external hostlist that is not git controlled';" >> $OUTPUTFILE;
+fi
+cat $OUTPUTFILE
+cp $OUTPUTFILE /var/www/healthcheck/sites.js
+rm -rf $TEMP_PATH

--- a/overlay/var/www/healthcheck/index.html
+++ b/overlay/var/www/healthcheck/index.html
@@ -1,0 +1,111 @@
+<html>
+<head>
+	<title>LanCache Host Checker</title>
+	<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+	<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+	<script src="sites.js"></script>
+	<script>
+		function checkDomain(domainname) {
+			var re = /^\*\./g
+			var domainname = domainname.replace(re, "lancachetest.");
+			return new Promise(function(resolve, reject) {
+				var handleResponse = function(xhr) {
+					if (xhr.status == 204) {
+						var respondingHost = xhr.getResponseHeader("X-LanCache-Processed-By");
+						return resolve(respondingHost);
+					}
+					console.log("Problem accessing", domainname)
+					return resolve(0);
+				}
+				$.ajax("http://" + domainname + "/steamcache-heartbeat",
+				{
+					success: function(data, textStatus, xhr){ 
+						handleResponse(xhr)
+					},
+					error: function(xhr){ 
+						handleResponse(xhr)
+					},
+
+				})
+			})
+		}
+		$(document).ready(function() {
+			var cdntemplate = $("#cdntemplate");
+			var cdnElements = {};
+			var domaincount = 0;
+			var providercount = 0;
+			var callbacks = {};
+			var distinctCaches = [];
+			for (var cdn in cachedomains) {
+				callbacks[cdn] = [];
+				providercount++;
+				domaincount += cachedomains[cdn].length;
+				cdnElements[cdn] = cdntemplate.clone().attr('id', 'cdn'+cdn).appendTo($("#cdns"));
+				$(cdnElements[cdn]).find("#title").html(cdn);
+				$(cdnElements[cdn]).find("#totalcdndomaincount").html(cachedomains[cdn].length);
+				for (var domain in cachedomains[cdn]) {
+					callbacks[cdn].push(checkDomain(cachedomains[cdn][domain]))
+				}
+				Promise.all(callbacks[cdn]).then(function(responses) {
+					var success = 0;
+					var fail = 0;
+					for (var x in responses) {
+						var response = responses[x];
+						if (response) {
+							success++;
+							if (distinctCaches.indexOf(response) == -1) {
+								distinctCaches.push(response);
+							}
+						} else {
+							fail++;
+						}
+					}
+					var newstate = "alert-success";
+					if (fail > 0) {
+						newstate = "alert-warning";
+					}
+					if (success == 0) {
+						newstate = "alert-danger";
+					}
+					this.find(".item").removeClass("alert-info").addClass(newstate);
+					this.find("#workingcdndomaincount").html(success);
+				}.bind(cdnElements[cdn]));
+			}
+			$("#urltext").html(urltext)
+			$("#domaincount").html(domaincount)
+			$("#providercount").html(providercount)
+			cdntemplate.hide()
+		});
+	</script>
+	<style>
+		.container-fluid {
+			max-width: 95%;
+		}
+		.cdnentry {
+			padding: 5px;
+		}
+	</style>
+</head>
+<body>
+	<div class="container-fluid">
+		<div class="jumbotron">
+			<div class="container">
+				<h1 class="display-4">Lancache/Monolithic Status page</h1>
+				<p class="lead">You currently have <b id="domaincount">0</b> domains spanning <b id="providercount">0</b> providers.</p>
+				<p id="urltext"></p>
+			</div>
+		</div>
+		<br>
+		<div id="cdns" class="row">
+			<div id="cdntemplate" class="cdnentry col-md-3 ">
+				<div class='item text-center border rounded alert-info'>
+					<b><span id="title">Nothing is defined?<br>I'm not sure how you've done this, but you have.<br>So well done.</span></b><br>
+					<span id="workingcdndomaincount">0</span>/<span id="totalcdndomaincount">0</span> domains working
+				</div>
+			</div>
+		</div>
+	</div>
+</body>
+</html>

--- a/overlay/var/www/healthcheck/index.html
+++ b/overlay/var/www/healthcheck/index.html
@@ -7,31 +7,84 @@
 	<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 	<script src="sites.js"></script>
 	<script>
-		function checkDomain(domainname) {
+		wildcardPrefix = "lancachetest."
+		function hideAlert() {
+			$("#cache-info").hide();
+		}
+
+		function displayCdnAlert(cdn) {
+			console.log(cdn, cachedomains[cdn]);
+			if (cachedomains[cdn].brokenDomains.length == 0) {
+				return hideAlert();
+			}
+			var newHTML = "";
+			for (var x in cachedomains[cdn].brokenDomains) {
+				newHTML += cachedomains[cdn].brokenDomains[x]+"<br>";
+			}
+			displayAlert("The following domains did not resolve to a LanCache instance:", newHTML);
+		}
+		function displayAlert(title, content, type="warning") {
+			$("#cache-info").removeClass("alert-warning").removeClass("alert-danger").removeClass("alert-success").addClass("alert-"+type);
+			$("#cache-info-display-title").html("<b>"+title+"</b><br>");
+			$("#cache-info-display").html(content);
+			$("#cache-info").show();
+		}
+
+		function checkDomain(cdn, domainname) {
 			var re = /^\*\./g
-			var domainname = domainname.replace(re, "lancachetest.");
+			var domainname = domainname.replace(re, wildcardPrefix);
 			return new Promise(function(resolve, reject) {
 				var handleResponse = function(xhr) {
-					if (xhr.status == 204) {
-						var respondingHost = xhr.getResponseHeader("X-LanCache-Processed-By");
-						return resolve(respondingHost);
+					if (xhr.host.indexOf(wildcardPrefix) > -1) {
+						xhr.host = xhr.host.replace(wildcardPrefix, "*.") + " (via "+xhr.host+")";
 					}
-					console.log("Problem accessing", domainname)
-					return resolve(0);
+					var ret = {
+						host: xhr.host,
+						status: 2,
+						cdn: cdn,
+						respondingHost: false,
+					};
+					if (xhr.status == 204) {
+						ret.respondingHost = xhr.getResponseHeader("X-LanCache-Processed-By");
+						ret.status = 1;
+						return resolve(ret);
+					}
+					ret.status = 0;
+					return resolve(ret);
 				}
 				$.ajax("http://" + domainname + "/steamcache-heartbeat",
 				{
+					beforeSend: function(xhr, settings) {
+						xhr.host = settings.url.match(/^http:\/\/(.+?)\/.+/)[1];
+					},
 					success: function(data, textStatus, xhr){ 
 						handleResponse(xhr)
 					},
-					error: function(xhr){ 
+					error: function(xhr){
 						handleResponse(xhr)
 					},
 
 				})
 			})
 		}
+
 		$(document).ready(function() {
+			hideAlert();
+			$("#inputTestButton").click(function() {
+				var url = $("#inputTest").val();
+				checkDomain(false, url).then(function(response) {
+					var alertType = "danger";
+					var alertTitle = "Test failed";
+					var alertText = url+" did not resolve to a LanCache instance";
+					if (response.status == 1) {
+						alertType = "success";
+						alertTitle = "Test Succeeded";
+						alertText = url+" resolves to a LanCache instance named "+response.respondingHost;
+					}
+					displayAlert(alertTitle, alertText, alertType)
+					console.log(response);
+				})
+			});
 			var cdntemplate = $("#cdntemplate");
 			var cdnElements = {};
 			var domaincount = 0;
@@ -40,25 +93,32 @@
 			var distinctCaches = [];
 			for (var cdn in cachedomains) {
 				callbacks[cdn] = [];
+				cachedomains[cdn].brokenDomains = [];
 				providercount++;
-				domaincount += cachedomains[cdn].length;
+				domaincount += cachedomains[cdn].domains.length;
 				cdnElements[cdn] = cdntemplate.clone().attr('id', 'cdn'+cdn).appendTo($("#cdns"));
 				$(cdnElements[cdn]).find("#title").html(cdn);
-				$(cdnElements[cdn]).find("#totalcdndomaincount").html(cachedomains[cdn].length);
-				for (var domain in cachedomains[cdn]) {
-					callbacks[cdn].push(checkDomain(cachedomains[cdn][domain]))
+				$(cdnElements[cdn]).find("#tagline").html(cachedomains[cdn].description);
+				$(cdnElements[cdn]).find("#totalcdndomaincount").html(cachedomains[cdn].domains.length);
+				$(cdnElements[cdn]).click(function() {
+					displayCdnAlert($(this).find("#title").html());
+				});
+				for (var domain in cachedomains[cdn].domains) {
+					callbacks[cdn].push(checkDomain(cdn, cachedomains[cdn].domains[domain]))
 				}
 				Promise.all(callbacks[cdn]).then(function(responses) {
+					var cdnname = this.find("#title").html();
 					var success = 0;
 					var fail = 0;
 					for (var x in responses) {
 						var response = responses[x];
-						if (response) {
+						if (response.status == 1) {
 							success++;
-							if (distinctCaches.indexOf(response) == -1) {
-								distinctCaches.push(response);
+							if (distinctCaches.indexOf(response.respondingHost) == -1) {
+								distinctCaches.push(response.respondingHost);
 							}
 						} else {
+							cachedomains[response.cdn].brokenDomains.push(response.host);
 							fail++;
 						}
 					}
@@ -86,11 +146,15 @@
 		.cdnentry {
 			padding: 5px;
 		}
+		.margin-fix {
+			margin-top: 5px;
+			margin-bottom: 0px;
+		}
 	</style>
 </head>
 <body>
 	<div class="container-fluid">
-		<div class="jumbotron">
+		<div class="jumbotron margin-fix">
 			<div class="container">
 				<h1 class="display-4">Lancache/Monolithic Status page</h1>
 				<p class="lead">You currently have <b id="domaincount">0</b> domains spanning <b id="providercount">0</b> providers.</p>
@@ -99,9 +163,37 @@
 		</div>
 		<br>
 		<div id="cdns" class="row">
-			<div id="cdntemplate" class="cdnentry col-md-3 ">
+			<div id="cdn-tester" class="cdnentry col-md-12">
+				<div class="item text-center border rounded alert alert-secondary">
+					<div class="form-group margin-fix">
+						<div class="col-sm-6 offset-sm-3">
+							<div class="input-group">
+								<input type="text" class="form-control rounded" id="inputTest" placeholder="Check domain (Wildcards valid)">
+								<span class="input-group-btn">
+									&nbsp;
+									<button id="inputTestButton" class="btn btn-primary mb-2">Test</button>
+							   </span>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="cdnentry col-md-12">
+				<div id="cache-info" class="item text-center border rounded alert alert-warning">
+					<button type="button" class="close" aria-label="Close">
+						<span aria-hidden="true" onclick="hideAlert()">&times;</span>
+					</button>
+					<span id="cache-info-display-title">
+						<b>The following domains did not resolve to a LanCache:</b><br>
+					</span>
+					<span id="cache-info-display">
+					</span>
+				</div>
+			</div>
+			<div id="cdntemplate" class="cdnentry col-md-3">
 				<div class='item text-center border rounded alert-info'>
-					<b><span id="title">Nothing is defined?<br>I'm not sure how you've done this, but you have.<br>So well done.</span></b><br>
+					<b><span id="title">Nothing is defined?<br>I'm not sure how you've done this, but you have.</span></b><br>
+					<span id="tagline">So well done.</span><br>
 					<span id="workingcdndomaincount">0</span>/<span id="totalcdndomaincount">0</span> domains working
 				</div>
 			</div>


### PR DESCRIPTION
Added a healthcheck site that requests /steamcache-heartbeat from each domain defined in the map file and reports back the status.
The goal is to increase confidence that CDNs are hitting the cache without the user having to test each individually.

https://i.imgur.com/CJI9Oe6.png

Considerations:
- replacement of 10_generic.conf, due to requiring two CORS headers, probably better placed in generic.
- Moving COPY overlay, this massively reduced my build time during development
- Default hostname could be something else. Should also probably be included into cache-domains. If it does, a specific exclude would be needed for this.