### PR TITLE
Inactive to match CACHE_MAX_AGE

### DIFF
--- a/overlay/etc/nginx/conf.d/20_proxy_cache_path.conf
+++ b/overlay/etc/nginx/conf.d/20_proxy_cache_path.conf
@@ -1,1 +1,1 @@
-proxy_cache_path /data/cache/cache levels=2:2 keys_zone=generic:CACHE_INDEX_SIZE inactive=200d max_size=CACHE_DISK_SIZE loader_files=1000 loader_sleep=50ms loader_threshold=300ms use_temp_path=off;
+proxy_cache_path /data/cache/cache levels=2:2 keys_zone=generic:CACHE_INDEX_SIZE inactive=CACHE_MAX_AGE max_size=CACHE_DISK_SIZE loader_files=1000 loader_sleep=50ms loader_threshold=300ms use_temp_path=off;

--- a/overlay/hooks/entrypoint-pre.d/10_setup.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_setup.sh
@@ -13,6 +13,7 @@ echo "worker_processes ${NGINX_WORKER_PROCESSES};" > /etc/nginx/workers.conf
 sed -i "s/^user .*/user ${WEBUSER};/" /etc/nginx/nginx.conf
 sed -i "s/CACHE_INDEX_SIZE/${CACHE_INDEX_SIZE}/"  /etc/nginx/conf.d/20_proxy_cache_path.conf
 sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/conf.d/20_proxy_cache_path.conf
+sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/" /etc/nginx/conf.d/20_proxy_cache_path.conf
 sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/cache.conf.d/root/20_cache.conf
 sed -i "s/slice 1m;/slice ${CACHE_SLICE_SIZE};/" /etc/nginx/sites-available/cache.conf.d/root/20_cache.conf
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/sites-available/cache.conf.d/10_root.conf


### PR DESCRIPTION
Cache was making inactive files invalid at an arbitrary time of 200d this will now be set to match CACHE_MAX_AGE. Hopefully this will produce a more consistent behaviour.