### PR TITLE
Add a health check to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,5 @@ VOLUME ["/data/logs", "/data/cache", "/data/cachedomains", "/var/www"]
 
 EXPOSE 80 443
 WORKDIR /scripts
+
+HEALTHCHECK CMD curl --fail http://127.0.0.1/lancache-heartbeat  || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ VOLUME ["/data/logs", "/data/cache", "/data/cachedomains", "/var/www"]
 EXPOSE 80 443
 WORKDIR /scripts
 
-HEALTHCHECK CMD curl --fail http://127.0.0.1/lancache-heartbeat  || exit 1
+HEALTHCHECK --interval=1m --timeout=1s --start-period=120s --retries=3 CMD curl --fail http://127.0.0.1/lancache-heartbeat  || exit 1


### PR DESCRIPTION
Allow to detect it there's problem with the nginx process and restart it.
Use the `/lancache-heartbeat` URL to check.

Based on: https://scoutapm.com/blog/how-to-use-docker-healthcheck