### PR TITLE
Fix wrong script syntax.

### DIFF
--- a/overlay/hooks/entrypoint-pre.d/10_setup.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_setup.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 set -e
 
 # Handle CACHE_MEM_SIZE deprecation


### PR DESCRIPTION
Fixes the following error in the Docker image:

```
Executing hook /hooks/entrypoint-pre.d/10_setup.sh
/hooks/entrypoint-pre.d/10_setup.sh: 5: /hooks/entrypoint-pre.d/10_setup.sh: [[: not found
```
