### PR TITLE
Add header for litmus test

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -24,5 +24,7 @@ http:
     status: 204
     allow-insecure: false
     no-follow-redirects: false
+    headers:
+      - "Access-Control-Allow-Private-Network: true"
     timeout: 0
     body: []

--- a/overlay/etc/nginx/sites-available/cache.conf.d/90_lancache_heartbeat.conf
+++ b/overlay/etc/nginx/sites-available/cache.conf.d/90_lancache_heartbeat.conf
@@ -1,5 +1,6 @@
   location = /lancache-heartbeat {
     add_header X-LanCache-Processed-By $hostname;
+    add_header 'Access-Control-Allow-Private-Network' 'true'; # CORS-RFC1918 for litmus tests
     add_header 'Access-Control-Expose-Headers' '*';
     add_header 'Access-Control-Allow-Origin' '*';
     return 204;


### PR DESCRIPTION
Add header to allow Chrome to do CORS requests on a different domain in the private network as per reference: https://developer.chrome.com/blog/private-network-access-preflight/

The goss file also check if it's enabled.

Allow to close issue #146