### PR TITLE
Log params

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ ENV GENERICCACHE_VERSION=2 \
     LOGFILE_RETENTION=3560 \
     CACHE_DOMAINS_REPO="https://github.com/uklans/cache-domains.git" \
     CACHE_DOMAINS_BRANCH=master \
-    NGINX_WORKER_PROCESSES=auto
+    NGINX_WORKER_PROCESSES=auto \
+    LOG_PARAMS=""
 
 COPY overlay/ /
 

--- a/overlay/etc/nginx/sites-available/10_cache.conf
+++ b/overlay/etc/nginx/sites-available/10_cache.conf
@@ -3,7 +3,7 @@
 server {
   listen 80 reuseport;
 
-  access_log /data/logs/access.log cachelog $LOG_PARAMS;
+  access_log /data/logs/access.log cachelog LOG_PARAMS;
   error_log /data/logs/error.log;
 
   include /etc/nginx/sites-available/cache.conf.d/*.conf;

--- a/overlay/etc/nginx/sites-available/10_cache.conf
+++ b/overlay/etc/nginx/sites-available/10_cache.conf
@@ -3,7 +3,7 @@
 server {
   listen 80 reuseport;
 
-  access_log /data/logs/access.log cachelog;
+  access_log /data/logs/access.log cachelog $LOG_PARAMS;
   error_log /data/logs/error.log;
 
   include /etc/nginx/sites-available/cache.conf.d/*.conf;

--- a/overlay/hooks/entrypoint-pre.d/10_setup.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_setup.sh
@@ -19,4 +19,4 @@ sed -i "s/slice 1m;/slice ${CACHE_SLICE_SIZE};/" /etc/nginx/sites-available/cach
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/sites-available/cache.conf.d/10_root.conf
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/sites-available/upstream.conf.d/10_resolver.conf
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/stream-available/10_sni.conf
-sed -i "s/UPSTREAM_DNS/${LOG_PARAMS}/"    /etc/nginx/sites-available/10_cache.conf
+sed -i "s/LOG_PARAMS/${LOG_PARAMS}/"    /etc/nginx/sites-available/10_cache.conf

--- a/overlay/hooks/entrypoint-pre.d/10_setup.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_setup.sh
@@ -19,3 +19,4 @@ sed -i "s/slice 1m;/slice ${CACHE_SLICE_SIZE};/" /etc/nginx/sites-available/cach
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/sites-available/cache.conf.d/10_root.conf
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/sites-available/upstream.conf.d/10_resolver.conf
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/stream-available/10_sni.conf
+sed -i "s/UPSTREAM_DNS/${LOG_PARAMS}/"    /etc/nginx/sites-available/10_cache.conf


### PR DESCRIPTION
Added a way to add parameters to the access log line. This is off by default but allows a user to select as the LOG_PARAMS env var if desired. eg.  `LOG_PARAMS=buffer=1m flush=3s`

- buffer=1m
- flush=3s
- gzip

