### PR TITLE
Local Build Script, for other architectures like arm64.

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -15,7 +15,7 @@ docker build -t lancachenet/ubuntu:latest --progress tty https://github.com/lanc
 
 #Removes standard Ubuntu image if not present before running:
 if [ "$IMAGEEXISTS" == false ]; then
-  printf "${PURPLEBOLD}Removing standart Ubuntu image:\n"
+  printf "${PURPLEBOLD}Removing standard Ubuntu image:\n"
   docker rmi ubuntu
 fi
 

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -13,7 +13,7 @@ fi
 printf "${PURPLEBOLD}Building temporary modified Ubuntu image:\n"
 docker build -t lancachenet/ubuntu:latest --progress tty https://github.com/lancachenet/ubuntu.git
 
-#Removes standart Ubuntu image if not present before running:
+#Removes standard Ubuntu image if not present before running:
 if [ "$IMAGEEXISTS" == false ]; then
   printf "${PURPLEBOLD}Removing standart Ubuntu image:\n"
   docker rmi ubuntu

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -14,7 +14,7 @@ printf "${PURPLEBOLD}Building temporary modified Ubuntu image:\n"
 docker build -t lancachenet/ubuntu:latest --progress tty https://github.com/lancachenet/ubuntu.git
 
 #Removes standart Ubuntu image if not present before running:
-if [$IMAGEEXISTS" == false]; then
+if [ "$IMAGEEXISTS" == false ]; then
   printf "${PURPLEBOLD}Removing standart Ubuntu image:\n"
   docker rmi ubuntu
 fi

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -3,11 +3,21 @@
 
 PURPLEBOLD="$(tput setf 5 bold)"
 
+#Checks if image ubuntu already exists:
+
+IMAGEEXISTS=true
+if [[ "$(docker image inspect ubuntu >/dev/null 2>&1 && echo true || echo false)" = "false" ]]; then
+  IMAGEEXISTS=false
+fi
+
 printf "${PURPLEBOLD}Building temporary modified Ubuntu image:\n"
 docker build -t lancachenet/ubuntu:latest --progress tty https://github.com/lancachenet/ubuntu.git
 
-printf "${PURPLEBOLD}Removing standart Ubuntu image:\n"
-docker rmi ubuntu
+#Removes standart Ubuntu image if not present before running:
+if [$IMAGEEXISTS" == false]; then
+  printf "${PURPLEBOLD}Removing standart Ubuntu image:\n"
+  docker rmi ubuntu
+fi
 
 printf  "${PURPLEBOLD}Building temporary Ubuntu-Nginx image:\n"
 docker build -t lancachenet/ubuntu-nginx:latest --progress tty https://github.com/lancachenet/ubuntu-nginx.git

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -6,7 +6,7 @@ PURPLEBOLD="$(tput setf 5 bold)"
 #Checks if image ubuntu already exists:
 
 IMAGEEXISTS=true
-if [[ "$(docker image inspect ubuntu >/dev/null 2>&1 && echo true || echo false)" = "false" ]]; then
+if [[ "$(docker image inspect ubuntu >/dev/null 2>&1 && echo true || echo false)" == "false" ]]; then
   IMAGEEXISTS=false
 fi
 


### PR DESCRIPTION
This script build the monolithic image locally, from the githubs pages. It's intended for cases like the raspberry pi, which operates on arm64 architecture, which isn't available as an image. See https://github.com/lancachenet/monolithic/issues/171.