### PR TITLE
Expose metrics from NGINX and Bind to Prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,5 @@ RUN git clone --depth=1 --no-single-branch https://github.com/uklans/cache-domai
 
 VOLUME ["/data/logs", "/data/cache", "/data/cachedomains", "/var/www"]
 
-EXPOSE 80 443
+EXPOSE 80 443 8080
 WORKDIR /scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN rm /etc/nginx/sites-enabled/* /etc/nginx/stream-enabled/* ;\
     mkdir -p /etc/nginx/sites-enabled	;\
     ln -s /etc/nginx/sites-available/10_cache.conf /etc/nginx/sites-enabled/10_generic.conf; \
     ln -s /etc/nginx/sites-available/20_upstream.conf /etc/nginx/sites-enabled/20_upstream.conf; \
+    ln -s /etc/nginx/sites-available/30_metrics.conf /etc/nginx/sites-enabled/30_metrics.conf; \
     ln -s /etc/nginx/stream-available/10_sni.conf /etc/nginx/stream-enabled/10_sni.conf; \
     mkdir -m 755 -p /data/cachedomains		;\
     mkdir -m 755 -p /tmp/nginx

--- a/overlay/etc/nginx/sites-available/30_metrics.conf
+++ b/overlay/etc/nginx/sites-available/30_metrics.conf
@@ -1,0 +1,9 @@
+# Metrics endpoint
+
+server {
+  listen 8080 reuseport;
+
+  location = /nginx_status {
+    stub_status;
+  }
+}


### PR DESCRIPTION
This update is the [monolithic](https://github.com/lancachenet/monolithic) update for the NGINX status export to Prometheus.

Please see https://github.com/lancachenet/docker-compose/issues/38 for further information about this update as this solves https://github.com/lancachenet/docker-compose/issues/38

In short, we have added a statistics endpoint, such that NGINX status data can be exported to Prometheus through [nginx/nginx-prometheus-exporter](https://github.com/nginxinc/nginx-prometheus-exporter).