### PR TITLE
Configure NGINX to listen on port 80 for IPv6

### DIFF
--- a/overlay/etc/nginx/sites-available/10_cache.conf
+++ b/overlay/etc/nginx/sites-available/10_cache.conf
@@ -2,6 +2,7 @@
 
 server {
   listen 80 reuseport;
+  listen [::]:80 reuseport;
 
   access_log /data/logs/access.log LOG_FORMAT;
   error_log /data/logs/error.log;


### PR DESCRIPTION
Configure NGINX to listen on port 80 for IPv6 addresses as well as IPv4