### PR TITLE
Fix redundant redirection in wget command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ version: 2.1
 executors:
   testbuild-executor:
     machine:
-      image: ubuntu-2004:202201-02
+      image: default
 jobs:
   test:
     executor: testbuild-executor

--- a/overlay/scripts/heartbeat.sh
+++ b/overlay/scripts/heartbeat.sh
@@ -12,5 +12,5 @@ fi
 
 while [ 1 ]; do
     sleep $BEATTIME;
-	wget http://127.0.0.1/lancache-heartbeat -S -O - > /dev/null 2>&1 /dev/null
+	wget http://127.0.0.1/lancache-heartbeat -S -O - > /dev/null 2>&1
 done


### PR DESCRIPTION
The original command had redundant redirections, which have been corrected to properly suppress both standard output and standard error.