### PR TITLE
Remove access logging on nginx_status endpoint

### DIFF
--- a/overlay/etc/nginx/sites-available/30_metrics.conf
+++ b/overlay/etc/nginx/sites-available/30_metrics.conf
@@ -4,6 +4,7 @@ server {
   listen 8080 reuseport;
 
   location = /nginx_status {
-    stub_status;
+    stub_status on;
+    access_log off;
   }
 }


### PR DESCRIPTION
Update NGINX configuration for the `/nginx_status` endpoint to enhance performance and optimize logging behavior. By disabling access logs for this endpoint, it reduces clutter in the logs when the status gets polled frequently by monitoring systems. Also explicitly enable `stub_status`.