### PR TITLE
feat: support backends that don't allow file owner changes

### DIFF
--- a/overlay/hooks/entrypoint-pre.d/20_perms_check.sh
+++ b/overlay/hooks/entrypoint-pre.d/20_perms_check.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 if [ -d "/data/cache/cache" ]; then
-	echo "Running fast permissions check"
-	ls -l /data/cache/cache | tail --lines=+2 | grep -v ${WEBUSER} > /dev/null
-
+	echo "Running fast permissions check - listing files that fail permission check:"
+	su - ${WEBUSER} -c 'find /data/cache/cache -maxdepth 1 ! -readable -o ! -writable | grep . && exit 1 || exit 0'
 	if [[ $? -eq 0 || "$FORCE_PERMS_CHECK" == "true" ]]; then
 		echo "Doing full checking of permissions (This WILL take a long time on large caches)..."
 		find /data \! -user ${WEBUSER} -exec chown ${WEBUSER}:${WEBUSER} '{}' +
@@ -10,5 +9,4 @@ if [ -d "/data/cache/cache" ]; then
 	else
 		echo "Fast permissions check successful, if you have any permissions error try running with -e FORCE_PERMS_CHECK = true"
 	fi
-
 fi


### PR DESCRIPTION
What it does:

- Checks the actual read/write ability of cache files by the cache user, instead of just checking ownership.

Why does it do that:

- Some storage backends don't support changing of file ownership. What lancache really cares about is whether it can read/write to the files, not whether it owns the files. If the location is read/writable, it's usable. This will allow for a wider variety of backend storage configurations.
- Because it would fix these two issues:
  - https://github.com/lancachenet/monolithic/issues/203
  - https://github.com/lancachenet/monolithic/issues/182

# Testing done
I've been running with this configmap in my cluster:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: lancache-script-permission-check
  namespace: "{{ lancache_namespace }}"
data:
  20_perms_check.sh: |
    #!/bin/bash
    if [ -d "/data/cache/cache" ]; then
      echo "Running fast permissions check - listing files that fail permission check:"
      su - ${WEBUSER} -c 'find /data/cache/cache -maxdepth 1 ! -readable -o ! -writable | grep . && exit 1 || exit 0'
      if [[ $? -eq 0 || "$FORCE_PERMS_CHECK" == "true" ]]; then
        echo "Doing full checking of permissions (This WILL take a long time on large caches)..."
        find /data \! -user ${WEBUSER} -exec chown ${WEBUSER}:${WEBUSER} '{}' +
        echo "Permissions ok"
      else
        echo "Fast permissions check successful, if you have any permissions error try running with -e FORCE_PERMS_CHECK = true"
      fi
    fi
```

and then these mods to the stateful set podspec to patch it in:
```
      volumes:
        - name: script-permission-check-configmap
          configMap:
            name: lancache-script-permission-check
            defaultMode: 0777
```

```
        volumeMounts:
          - name: script-permission-check-configmap
            mountPath: /hooks/entrypoint-pre.d/20_perms_check.sh
            subPath: 20_perms_check.sh
```

It works as expected and I have not suffered any ill effects on a 1.5TB cache.