### PR TITLE
Ignore Set-Cookie to mitigate Cloudflare BYPASS

### DIFF
--- a/overlay/etc/nginx/sites-available/cache.conf.d/root/20_cache.conf
+++ b/overlay/etc/nginx/sites-available/cache.conf.d/root/20_cache.conf
@@ -2,7 +2,7 @@
     slice 1m;
     proxy_cache generic;
 
-    proxy_ignore_headers Expires Cache-Control;
+    proxy_ignore_headers Expires Cache-Control Set-Cookie;
     proxy_cache_valid 200 206 CACHE_MAX_AGE;
     proxy_set_header  Range $slice_range;
 


### PR DESCRIPTION
Ignore Set-Cookie to mitigate Cloudflare BYPASS problem.  Fixes #201 