### PR TITLE
feat: generate config for upstreams with keepalive enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL description="Single caching container for caching game content at LAN part
 LABEL maintainer="LanCache.Net Team <team@lancache.net>"
 
 RUN	apt-get update							;\
-	apt-get install -y jq git				;
+	apt-get install -y jq git dnsutils		;
 
 ENV GENERICCACHE_VERSION=2 \
     CACHE_MODE=monolithic \

--- a/overlay/etc/nginx/conf.d/35_upstream_maps.conf
+++ b/overlay/etc/nginx/conf.d/35_upstream_maps.conf
@@ -1,0 +1,4 @@
+# Default passthrough map - overwritten when ENABLE_UPSTREAM_KEEPALIVE=true
+map $http_host $upstream_name {
+    default $host;
+}

--- a/overlay/etc/nginx/sites-available/upstream.conf.d/30_primary_proxy.conf
+++ b/overlay/etc/nginx/sites-available/upstream.conf.d/30_primary_proxy.conf
@@ -1,7 +1,11 @@
   # Proxy all requests to upstream
   location / {
-    # Simple proxy the request
-    proxy_pass http://$host$request_uri;
+    # Enable HTTP/1.1 and keepalive for supported upstreams
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+
+    # Proxy using upstream pools (falls back to $host if not mapped)
+    proxy_pass http://$upstream_name$request_uri;
 
     # Catch the errors to process the redirects
     proxy_intercept_errors on;

--- a/overlay/etc/supervisor/conf.d/upstream_refresh.conf
+++ b/overlay/etc/supervisor/conf.d/upstream_refresh.conf
@@ -1,0 +1,6 @@
+[program:upstream_refresh]
+command=/scripts/refresh_upstreams.sh
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/overlay/hooks/entrypoint-pre.d/16_generate_upstream_keepalive.sh
+++ b/overlay/hooks/entrypoint-pre.d/16_generate_upstream_keepalive.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+set -e
+
+# Generates upstream pools with keepalive for concrete (non-wildcard) domains
+# from cache_domains.json
+
+# Note: 'resolve' parameter not used - requires nginx 1.27.3+
+# Currently DNS resolution happens at nginx startup/reload
+# To enable dynamic DNS resolution when nginx >= 1.27.3, edit pools conf:
+#   1. Add 'resolver ${UPSTREAM_DNS} ipv6=off;' at start of the file
+#   2. Add 'resolve' parameter to each 'server' directive
+
+IFS=' '
+cd /data/cachedomains
+
+TEMP_PATH=$(mktemp -d)
+POOLS_FILE="${TEMP_PATH}/pools.conf"
+MAPS_FILE="${TEMP_PATH}/maps.conf"
+
+echo "Generating upstream keepalive pools from cache_domains.json"
+
+# Initialize pools file
+echo "# Auto-generated upstream pools with keepalive" > "$POOLS_FILE"
+echo "# Generated from cache_domains.json at $(date)" >> "$POOLS_FILE"
+echo "" >> "$POOLS_FILE"
+
+# Initialize maps file
+echo "# Map hostnames to upstream pools for keepalive routing" > "$MAPS_FILE"
+echo "" >> "$MAPS_FILE"
+echo "map \$http_host \$upstream_name {" >> "$MAPS_FILE"
+echo "    hostnames;" >> "$MAPS_FILE"
+echo "    default \$host;  # Fallback to direct proxy for unmapped domains" >> "$MAPS_FILE"
+
+# Loop through each cache service
+# Using process substitution to avoid subshell context issues with pipes
+while read CACHE_ENTRY; do
+    # Get service name
+    SERVICE_NAME=$(jq -r ".cache_domains[$CACHE_ENTRY].name" cache_domains.json)
+
+    echo "Processing service: ${SERVICE_NAME}"
+
+    # Loop through domain files for this service
+    while read CACHEHOSTS_FILEID; do
+        # Get the domain file name
+        CACHEHOSTS_FILENAME=$(jq -r ".cache_domains[$CACHE_ENTRY].domain_files[$CACHEHOSTS_FILEID]" cache_domains.json)
+
+        if [ ! -f "${CACHEHOSTS_FILENAME}" ]; then
+            echo "  Warning: Domain file not found: ${CACHEHOSTS_FILENAME}"
+            continue
+        fi
+
+        # Read each domain from the file
+        while read DOMAIN; do
+            # Skip empty lines and whitespace
+            DOMAIN=$(echo "$DOMAIN" | tr -d '[:space:]')
+            if [ -z "$DOMAIN" ]; then
+                continue
+            fi
+
+            # Skip comments
+            if [[ "$DOMAIN" =~ ^# ]]; then
+                continue
+            fi
+
+            # Skip wildcards - can't create upstream for *.example.com
+            if [[ "$DOMAIN" =~ \* ]]; then
+                echo "  Skipping wildcard: $DOMAIN"
+                continue
+            fi
+
+            # Check if domain resolves - skip if it doesn't (prevents nginx startup failure)
+            if ! getent hosts "$DOMAIN" >/dev/null 2>&1; then
+                echo "  Skipping unresolvable domain: $DOMAIN"
+                continue
+            fi
+
+            echo "  Adding upstream for: $DOMAIN"
+
+            # Sanitize domain name for use as upstream name
+            # Replace dots and dashes with underscores
+            UPSTREAM_NAME=$(echo "$DOMAIN" | sed 's/[.-]/_/g')
+
+            # Generate upstream block
+            cat >> "$POOLS_FILE" <<EOF
+upstream ${UPSTREAM_NAME} {
+    server ${DOMAIN}:443;
+    keepalive 16;
+    keepalive_timeout 5m;
+}
+
+EOF
+
+            # Add mapping entry
+            echo "    ${DOMAIN} ${UPSTREAM_NAME};" >> "$MAPS_FILE"
+        done < "${CACHEHOSTS_FILENAME}"
+    done < <(jq -r ".cache_domains[$CACHE_ENTRY].domain_files | to_entries[] | .key" cache_domains.json)
+done < <(jq -r '.cache_domains | to_entries[] | .key' cache_domains.json)
+
+# Close the map block
+echo "}" >> "$MAPS_FILE"
+
+# Copy to final locations
+cp "$POOLS_FILE" /etc/nginx/conf.d/40_upstream_pools.conf
+cp "$MAPS_FILE" /etc/nginx/conf.d/35_upstream_maps.conf
+
+# Validate final configuration after copying
+echo "Validating final nginx configuration..."
+if nginx -t 2>/dev/null; then
+    echo "✓ Nginx configuration is valid"
+    echo "Output files:"
+    echo "  - /etc/nginx/conf.d/40_upstream_pools.conf"
+    echo "  - /etc/nginx/conf.d/35_upstream_maps.conf"
+else
+    echo "ERROR: Generated keepalive configuration caused nginx validation to fail!"
+    echo "Rolling back generated files to allow nginx to start normally..."
+    rm -f /etc/nginx/conf.d/40_upstream_pools.conf
+    rm -f /etc/nginx/conf.d/35_upstream_maps.conf
+fi
+
+# Cleanup
+rm -rf "$TEMP_PATH"

--- a/overlay/hooks/entrypoint-pre.d/16_generate_upstream_keepalive.sh
+++ b/overlay/hooks/entrypoint-pre.d/16_generate_upstream_keepalive.sh
@@ -9,6 +9,9 @@ if [[ "${ENABLE_UPSTREAM_KEEPALIVE}" != "true" ]]; then
     exit 0
 fi
 
+# Normalize UPSTREAM_DNS (allow semicolons like lancache-dns)
+UPSTREAM_DNS="$(echo -n "${UPSTREAM_DNS}" | sed 's/[;]/ /g')"
+
 # DNS is resolved at generation time using UPSTREAM_DNS.
 # The refresh_upstreams.sh script re-runs this periodically to keep IPs current.
 #

--- a/overlay/hooks/entrypoint-pre.d/16_generate_upstream_keepalive.sh
+++ b/overlay/hooks/entrypoint-pre.d/16_generate_upstream_keepalive.sh
@@ -14,22 +14,25 @@ IFS=' '
 cd /data/cachedomains
 
 TEMP_PATH=$(mktemp -d)
-POOLS_FILE="${TEMP_PATH}/pools.conf"
-MAPS_FILE="${TEMP_PATH}/maps.conf"
+POOLS_TMP_FILE="${TEMP_PATH}/pools.conf"
+POOLS_FILE="/etc/nginx/conf.d/40_upstream_pools.conf"
+MAPS_TMP_FILE="${TEMP_PATH}/maps.conf"
+MAPS_FILE="/etc/nginx/conf.d/35_upstream_maps.conf"
 
 echo "Generating upstream keepalive pools from cache_domains.json"
 
 # Initialize pools file
-echo "# Auto-generated upstream pools with keepalive" > "$POOLS_FILE"
-echo "# Generated from cache_domains.json at $(date)" >> "$POOLS_FILE"
-echo "" >> "$POOLS_FILE"
+echo "# Auto-generated upstream pools with keepalive" > "$POOLS_TMP_FILE"
+echo "# Generated from cache_domains.json at $(date)" >> "$POOLS_TMP_FILE"
+echo "" >> "$POOLS_TMP_FILE"
 
 # Initialize maps file
-echo "# Map hostnames to upstream pools for keepalive routing" > "$MAPS_FILE"
-echo "" >> "$MAPS_FILE"
-echo "map \$http_host \$upstream_name {" >> "$MAPS_FILE"
-echo "    hostnames;" >> "$MAPS_FILE"
-echo "    default \$host;  # Fallback to direct proxy for unmapped domains" >> "$MAPS_FILE"
+echo "# Map hostnames to upstream pools for keepalive routing" > "$MAPS_TMP_FILE"
+echo "" >> "$MAPS_TMP_FILE"
+echo "map \$http_host \$upstream_name {" >> "$MAPS_TMP_FILE"
+echo "    hostnames;" >> "$MAPS_TMP_FILE"
+echo "    default \$host;  # Fallback to direct proxy for unmapped domains" >> "$MAPS_TMP_FILE"
+echo "    *.steamcontent.com lancache_steamcontent_com; # Redirect all steam traffic" >> "$MAPS_TMP_FILE"
 
 # Loop through each cache service
 # Using process substitution to avoid subshell context issues with pipes
@@ -68,22 +71,24 @@ while read CACHE_ENTRY; do
                 continue
             fi
 
-            # Check if domain resolves - skip if it doesn't (prevents nginx startup failure)
-            if ! getent hosts "$DOMAIN" >/dev/null 2>&1; then
+            # Resolve domain using external DNS to bypass local lancache DNS overrides
+            # This prevents nginx from looping back to itself
+            RESOLVED_IP=$(dig +short +time=2 +tries=1 "$DOMAIN" @${UPSTREAM_DNS%% *} 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+            if [ -z "$RESOLVED_IP" ]; then
                 echo "  Skipping unresolvable domain: $DOMAIN"
                 continue
             fi
 
-            echo "  Adding upstream for: $DOMAIN"
+            echo "  Adding upstream for: $DOMAIN -> $RESOLVED_IP"
 
             # Sanitize domain name for use as upstream name
             # Replace dots and dashes with underscores
             UPSTREAM_NAME=$(echo "$DOMAIN" | sed 's/[.-]/_/g')
 
-            # Generate upstream block
-            cat >> "$POOLS_FILE" <<EOF
+            # Generate upstream block with resolved IP
+            cat >> "$POOLS_TMP_FILE" <<EOF
 upstream ${UPSTREAM_NAME} {
-    server ${DOMAIN}:443;
+    server ${RESOLVED_IP};  # $DOMAIN
     keepalive 16;
     keepalive_timeout 5m;
 }
@@ -91,30 +96,30 @@ upstream ${UPSTREAM_NAME} {
 EOF
 
             # Add mapping entry
-            echo "    ${DOMAIN} ${UPSTREAM_NAME};" >> "$MAPS_FILE"
+            echo "    ${DOMAIN} ${UPSTREAM_NAME};" >> "$MAPS_TMP_FILE"
         done < "${CACHEHOSTS_FILENAME}"
     done < <(jq -r ".cache_domains[$CACHE_ENTRY].domain_files | to_entries[] | .key" cache_domains.json)
 done < <(jq -r '.cache_domains | to_entries[] | .key' cache_domains.json)
 
 # Close the map block
-echo "}" >> "$MAPS_FILE"
+echo "}" >> "$MAPS_TMP_FILE"
 
 # Copy to final locations
-cp "$POOLS_FILE" /etc/nginx/conf.d/40_upstream_pools.conf
-cp "$MAPS_FILE" /etc/nginx/conf.d/35_upstream_maps.conf
+cp "$POOLS_TMP_FILE" $POOLS_FILE
+cp "$MAPS_TMP_FILE" $MAPS_FILE
 
 # Validate final configuration after copying
 echo "Validating final nginx configuration..."
 if nginx -t 2>/dev/null; then
     echo "✓ Nginx configuration is valid"
     echo "Output files:"
-    echo "  - /etc/nginx/conf.d/40_upstream_pools.conf"
-    echo "  - /etc/nginx/conf.d/35_upstream_maps.conf"
+    echo "  - $POOLS_FILE"
+    echo "  - $MAPS_FILE"
 else
     echo "ERROR: Generated keepalive configuration caused nginx validation to fail!"
     echo "Rolling back generated files to allow nginx to start normally..."
-    rm -f /etc/nginx/conf.d/40_upstream_pools.conf
-    rm -f /etc/nginx/conf.d/35_upstream_maps.conf
+    rm -f $POOLS_FILE
+    rm -f $MAPS_FILE
 fi
 
 # Cleanup

--- a/overlay/hooks/entrypoint-pre.d/16_generate_upstream_keepalive.sh
+++ b/overlay/hooks/entrypoint-pre.d/16_generate_upstream_keepalive.sh
@@ -4,6 +4,11 @@ set -e
 # Generates upstream pools with keepalive for concrete (non-wildcard) domains
 # from cache_domains.json
 
+if [[ "${ENABLE_UPSTREAM_KEEPALIVE}" != "true" ]]; then
+    echo "Upstream keepalive disabled (set ENABLE_UPSTREAM_KEEPALIVE=true to enable)"
+    exit 0
+fi
+
 # Note: 'resolve' parameter not used - requires nginx 1.27.3+
 # Currently DNS resolution happens at nginx startup/reload
 # To enable dynamic DNS resolution when nginx >= 1.27.3, edit pools conf:

--- a/overlay/scripts/refresh_upstreams.sh
+++ b/overlay/scripts/refresh_upstreams.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [[ "${ENABLE_UPSTREAM_KEEPALIVE}" != "true" ]]; then
+    exit 0
+fi
+
 REFRESH_INTERVAL=${UPSTREAM_REFRESH_INTERVAL:-1h}
 
 if [[ "$REFRESH_INTERVAL" == "0" ]]; then

--- a/overlay/scripts/refresh_upstreams.sh
+++ b/overlay/scripts/refresh_upstreams.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+REFRESH_INTERVAL=${UPSTREAM_REFRESH_INTERVAL:-1h}
+
+if [[ "$REFRESH_INTERVAL" == "0" ]]; then
+    echo "Upstream refresh disabled (UPSTREAM_REFRESH_INTERVAL=0)"
+    exit 0
+fi
+
+echo "Starting upstream refresh loop (interval: $REFRESH_INTERVAL)"
+
+while true; do
+    sleep $REFRESH_INTERVAL
+
+    echo "[$(date)] Refreshing upstream pools..."
+
+    if /hooks/entrypoint-pre.d/16_generate_upstream_keepalive.sh > /dev/null 2>&1; then
+        nginx -s reload
+        echo "[$(date)] Upstream pools refreshed and nginx reloaded"
+    else
+        echo "[$(date)] Upstream generation failed, skipping reload"
+    fi
+done


### PR DESCRIPTION
Enables HTTP/1.1 keepalive connections to upstream CDNs, improving _cache-miss_ download speeds. On my setup I was able to increase throughput for 1 user/client from 200Mbps to ~1Gbps for Steam (my ISP speed). This will benefit everyone, but it is most obvious in home situations.

### How it works

- Auto-generates upstream blocks with keepalive pools from `cache_domains.json` at container startup
- Maps CDN domains to their keepalive pools via `$upstream_name` variable
- Enables HTTP/1.1 with `Connection: ""` header to reuse TCP connections
- Unresolvable/wildcard domains fall back to direct proxy (no keepalive)
- Periodically re-resolves DNS via a supervisord-managed refresh loop

In nginx 1.27.3 [`resolve`](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#resolve) is available for non-commercial users which would be a much cleaner implementation of this. The refresh script and the scripted resolution of hosts could be removed at that point.

### Configuration

This feature is opt-in. Set the following environment variables:

| Variable | Default | Description |
|----------|---------|-------------|
| `ENABLE_UPSTREAM_KEEPALIVE` | `false` | Set to `true` to enable |
| `UPSTREAM_REFRESH_INTERVAL` | `1h` | How often to re-resolve DNS (set to `0` to disable refresh) |

### Changes

- **`overlay/hooks/entrypoint-pre.d/16_generate_upstream_keepalive.sh`** - Entrypoint hook to generate upstream configs at startup
- **`overlay/scripts/refresh_upstreams.sh`** - Periodic DNS refresh loop
- **`overlay/etc/supervisor/conf.d/upstream_refresh.conf`** - Supervisord program for the refresh loop
- **`overlay/etc/nginx/sites-available/upstream.conf.d/30_primary_proxy.conf`** - Modified to use HTTP/1.1 keepalive and route via `$upstream_name`

Generated at runtime:
- `/etc/nginx/conf.d/40_upstream_pools.conf` - Upstream blocks with keepalive directives
- `/etc/nginx/conf.d/35_upstream_maps.conf` - Domain to upstream mappings

### Why this works

Many games/downloads fetch content as tiny chunks under 1MB. Without keepalive, each chunk requires a new TCP connection leading to massive overhead. Personally I tried adjusting settings with lancache (like slice size) but this ended up being the bottleneck.

Closes #202

## Generated config examples (removed most of the content for brevity)

### /etc/nginx/conf.d/35_upstream_maps.conf
```nginx
# Map hostnames to upstream pools for keepalive routing

map $http_host $upstream_name_default {
    hostnames;
    default $host;  # Fallback to direct proxy for unmapped domains
    assetcdn.101.arenanetworks.com assetcdn_101_arenanetworks_com;
    # snip
    xvcf2.xboxlive.com xvcf2_xboxlive_com;
}

# Steam user-agent detection - routes Steam client traffic to steam upstream pool
map $http_user_agent $upstream_name {
    default $upstream_name_default;
    ~Valve\/Steam\ HTTP\ Client\ 1\.0 lancache_steamcontent_com;
}
```

### /etc/nginx/conf.d/40_upstream_pools.conf

```nginx
# Auto-generated upstream pools with keepalive
# Generated from cache_domains.json at Thu 15 Jan 17:54:13 EST 2026

upstream assetcdn_101_arenanetworks_com {
    server 13.249.82.104;  # assetcdn.101.arenanetworks.com
    keepalive 16;
    keepalive_timeout 5m;
}

upstream assetcdn_102_arenanetworks_com {
    server 3.171.73.128;  # assetcdn.102.arenanetworks.com
    keepalive 16;
    keepalive_timeout 5m;
}

upstream assetcdn_103_arenanetworks_com {
    server 3.170.43.196;  # assetcdn.103.arenanetworks.com
    keepalive 16;
    keepalive_timeout 5m;
}

# ... snip

upstream xbox_mbr_xboxlive_com {
    server 104.97.85.167;  # xbox-mbr.xboxlive.com
    keepalive 16;
    keepalive_timeout 5m;
}

upstream xvcf1_xboxlive_com {
    server 23.53.11.15;  # xvcf1.xboxlive.com
    keepalive 16;
    keepalive_timeout 5m;
}

upstream xvcf2_xboxlive_com {
    server 23.3.75.133;  # xvcf2.xboxlive.com
    keepalive 16;
    keepalive_timeout 5m;
}
```