### PR TITLE
Add helper message for checking logs

### DIFF
--- a/overlay/hooks/supervisord-pre.d/99_config_check.sh
+++ b/overlay/hooks/supervisord-pre.d/99_config_check.sh
@@ -7,3 +7,11 @@ echo "Checking nginx config"
 /usr/sbin/nginx -t
 
  [ $? -ne 0 ] || echo "Config check successful"
+
+echo "Ready for supervisord startup"
+if [ -n "$CACHE_ROOT" ]
+then
+     echo "Monitor ${CACHE_ROOT}/logs/access.log and ${CACHE_ROOT}/logs/error.log on the host for cache activity"
+else
+    echo "Monitor access.log and error.log on the host for cache activity"
+fi

--- a/overlay/hooks/supervisord-pre.d/99_config_check.sh
+++ b/overlay/hooks/supervisord-pre.d/99_config_check.sh
@@ -11,7 +11,7 @@ echo "Checking nginx config"
 echo "Ready for supervisord startup"
 if [ -n "$CACHE_ROOT" ]
 then
-     echo "Monitor ${CACHE_ROOT}/logs/access.log and ${CACHE_ROOT}/logs/error.log on the host for cache activity"
+    echo "Monitor ${CACHE_ROOT}/logs/access.log and ${CACHE_ROOT}/logs/error.log on the host for cache activity"
 else
     echo "Monitor access.log and error.log on the host for cache activity"
 fi

--- a/overlay/scripts/cache_test.sh
+++ b/overlay/scripts/cache_test.sh
@@ -9,9 +9,16 @@ sleep 5
 pageload4=`curl http://worldtimeapi.org/api/timezone/ETC/GMT --resolve worldtimeapi.org:80:127.0.0.1`
 if [ "$pageload1" == "$pageload2" ]; then
 	if [ "$pageload3" == "$pageload4" ]; then
-		if [ "$pageload1" == "$pageload4" ]; then
+		if [ "$pageload1" == "$pageload3" ]; then
 			#In monolithic pages 1+3 should be different as there is no map for this test case
 			echo "Error caching test page, pages 1+3 are identical"
+	
+			echo "pageload1:"
+			echo $pageload1
+
+			echo "pageload3:"
+			echo $pageload3
+			
 			exit -3
 		else
 			echo "Succesfully Cached"
@@ -20,10 +27,26 @@ if [ "$pageload1" == "$pageload2" ]; then
 
 	else
 		echo "Error caching test page, pages 3+4 differed"
+
+	
+			echo "pageload3:"
+			echo $pageload3
+
+			echo "pageload4:"
+			echo $pageload4
+		
 		exit -2
 	fi
 
 else
 	echo "Error caching test page, pages 1+2 differed"
+
+
+	echo "pageload1:"
+	echo $pageload1
+
+	echo "pageload2:"
+	echo $pageload2
+	
 	exit -1
 fi

--- a/overlay/scripts/cache_test.sh
+++ b/overlay/scripts/cache_test.sh
@@ -1,25 +1,26 @@
 #!/bin/bash
 set -e
-pageload1=`curl http://www.worldtimeapi.org/api/timezone/ETC/GMT --resolve www.worldtimeapi.org:80:127.0.0.1`
-sleep 5
-pageload2=`curl http://www.worldtimeapi.org/api/timezone/ETC/GMT --resolve www.worldtimeapi.org:80:127.0.0.1`
-sleep 5
-pageload3=`curl http://worldtimeapi.org/api/timezone/ETC/GMT --resolve worldtimeapi.org:80:127.0.0.1`
-sleep 5
-pageload4=`curl http://worldtimeapi.org/api/timezone/ETC/GMT --resolve worldtimeapi.org:80:127.0.0.1`
+pageload1=`curl http://ping1.lancache.net/api/timezone/ETC/GMT --resolve ping1.lancache.net:80:127.0.0.1`
+sleep 2
+pageload2=`curl http://ping1.lancache.net/api/timezone/ETC/GMT --resolve ping1.lancache.net:80:127.0.0.1`
+sleep 2
+pageload3=`curl http://ping2.lancache.net/api/timezone/ETC/GMT --resolve ping2.lancache.net:80:127.0.0.1`
+sleep 2
+pageload4=`curl http://ping2.lancache.net/api/timezone/ETC/GMT --resolve ping2.lancache.net:80:127.0.0.1`
+
 if [ "$pageload1" == "$pageload2" ]; then
 	if [ "$pageload3" == "$pageload4" ]; then
 		if [ "$pageload1" == "$pageload3" ]; then
 			#In monolithic pages 1+3 should be different as there is no map for this test case
 			echo "Error caching test page, pages 1+3 are identical"
-	
+
 			echo "pageload1:"
 			echo $pageload1
 
 			echo "pageload3:"
 			echo $pageload3
-			
-			exit -3
+
+			exit 3
 		else
 			echo "Succesfully Cached"
 			exit 0
@@ -28,14 +29,14 @@ if [ "$pageload1" == "$pageload2" ]; then
 	else
 		echo "Error caching test page, pages 3+4 differed"
 
-	
-			echo "pageload3:"
-			echo $pageload3
 
-			echo "pageload4:"
-			echo $pageload4
-		
-		exit -2
+		echo "pageload3:"
+		echo $pageload3
+
+		echo "pageload4:"
+		echo $pageload4
+
+		exit 2
 	fi
 
 else
@@ -47,6 +48,6 @@ else
 
 	echo "pageload2:"
 	echo $pageload2
-	
-	exit -1
+
+	exit 1
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,4 +6,4 @@ else
 	SD_LOGLEVEL="-- -e SUPERVISORD_LOGLEVEL=INFO"
 fi
 
-curl -fsSL https://raw.githubusercontent.com/lancachenet/test-suite/master/dgoss-tests.sh | bash -s -- --imagename="lancachenet/monolithic:goss-test" $@ $SD_LOGLEVEL
+curl -fsSL https://raw.githubusercontent.com/lancachenet/test-suite/master/dgoss-tests.sh | bash -s -- --imagename="lancachenet/monolithic:goss-test" $@ $SD_LOGLEVEL -e GOSS_LOGLEVEL=DEBUG


### PR DESCRIPTION
We keep getting issues with "Lancache isn't working it started supervisord and got no further". This commit adds additional information to the config check which if successful will warn about checking access log after supervisord has started

Example:
https://github.com/lancachenet/monolithic/issues/218