### PR TITLE
Enable IPv6 support for HTTPS SNI passthrough

### DIFF
--- a/overlay/etc/nginx/stream-available/10_sni.conf
+++ b/overlay/etc/nginx/stream-available/10_sni.conf
@@ -1,5 +1,7 @@
 server {
-  listen 443;
+  listen 443 reuseport;
+  listen [::]:443 reuseport;
+
   resolver UPSTREAM_DNS ipv6=off;
   proxy_pass  $ssl_preread_server_name:443;
   ssl_preread on;


### PR DESCRIPTION
Update 10_sni.conf to listen on ipv6 port too and use reuseport like [10_cache.conf](https://github.com/lancachenet/monolithic/blob/master/overlay/etc/nginx/sites-available/10_cache.conf)

As it is right now, accessing cached domains over HTTP on IPv6 works fine, but not over HTTPS because nginx isn't configured to listen on IPv6 for port 443.